### PR TITLE
Eenhance ExtractParams type to support optional params in route segments

### DIFF
--- a/src/sitemap-types.ts
+++ b/src/sitemap-types.ts
@@ -5,12 +5,7 @@ type SplitPath<S extends string> = S extends `${infer Segment}/${infer Rest}`
 
 /** If any segment starts with `$`, treat it as a param name. */
 type ExtractParams<S extends string> = {
-	[K in SplitPath<S> as K extends `$${infer Param}`
-		? Param
-		: /** If any segment is as an optional param {-$data} */
-			K extends `{-$${infer Param}}`
-			? Param
-			: never]: string;
+  [K in SplitPath<S> as K extends `$${infer Param}` | `{-$${infer Param}}` ? Param : never]: string;
 };
 
 /** Check if a route string has any `$` segments. */

--- a/src/sitemap-types.ts
+++ b/src/sitemap-types.ts
@@ -5,7 +5,12 @@ type SplitPath<S extends string> = S extends `${infer Segment}/${infer Rest}`
 
 /** If any segment starts with `$`, treat it as a param name. */
 type ExtractParams<S extends string> = {
-  [K in SplitPath<S> as K extends `$${infer Param}` ? Param : never]: string;
+	[K in SplitPath<S> as K extends `$${infer Param}`
+		? Param
+		: /** If any segment is as an optional param {-$data} */
+			K extends `{-$${infer Param}}`
+			? Param
+			: never]: string;
 };
 
 /** Check if a route string has any `$` segments. */


### PR DESCRIPTION
Before - it was extracting only dynamic params (/path/$param)

The template for optional params looks like /path/{-$param} https://tanstack.com/router/v1/docs/framework/react/guide/path-params#optional-path-parameters

Now it extracts it as a param as well, so the users can define sitemap configuration for the route as a DynamicRouteValue